### PR TITLE
Adjust analyzer startup

### DIFF
--- a/postprocessing/Song/BaseSongTest.py
+++ b/postprocessing/Song/BaseSongTest.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock, Mock
+import sitecustomize
 
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import ID3Tags

--- a/postprocessing/Song/TagCollectionTest.py
+++ b/postprocessing/Song/TagCollectionTest.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
+import sitecustomize
 
 from mutagen.id3 import TPE1
 

--- a/postprocessing/analyzer.py
+++ b/postprocessing/analyzer.py
@@ -25,7 +25,11 @@ class Analyzer(threading.Thread):
 
         self.queue = queue.Queue()
         self._running = True
+
+    def start(self):
+        """Start the analyzer thread and clear previous analysis data."""
         self._truncate_tables()
+        super().start()
 
     def _truncate_tables(self):
         logging.info("Clearing existing analysis data...")

--- a/tests/AnalyzerTest.py
+++ b/tests/AnalyzerTest.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import types
+import unittest
+
+# Provide required environment variables
+os.environ.setdefault('DB_HOST', 'localhost')
+os.environ.setdefault('DB_USER', 'user')
+os.environ.setdefault('DB_PORT', '3306')
+os.environ.setdefault('DB_PASS', 'pass')
+
+# Stub pymysql.connect
+class DummyCursor:
+    def execute(self, *a, **k):
+        pass
+    def fetchone(self):
+        return [1]
+    def close(self):
+        pass
+
+class DummyConnection:
+    def cursor(self):
+        return DummyCursor()
+    def close(self):
+        pass
+
+def dummy_connect(*a, **k):
+    return DummyConnection()
+
+pymysql_mod = types.ModuleType('pymysql')
+pymysql_mod.connect = dummy_connect
+sys.modules['pymysql'] = pymysql_mod
+
+from postprocessing.analyzer import Analyzer
+
+class AnalyzerTest(unittest.TestCase):
+    def test_truncate_called_on_start_only(self):
+        calls = []
+        original = Analyzer._truncate_tables
+        Analyzer._truncate_tables = lambda self: calls.append(True)
+        try:
+            analyzer = Analyzer()
+            # _truncate_tables should not have been called during initialization
+            self.assertEqual(calls, [])
+            analyzer.start()
+            analyzer.stop()
+            analyzer.join()
+            # now _truncate_tables should have been called exactly once
+            self.assertEqual(calls, [True])
+        finally:
+            Analyzer._truncate_tables = original
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/SoundcloudDownloaderTest.py
+++ b/tests/SoundcloudDownloaderTest.py
@@ -80,7 +80,7 @@ class SoundcloudDownloaderTest(unittest.TestCase):
         self.assertIsNotNone(dl._match_filter(too_short))
         ok = {'duration': 100, 'title': 'b'}
         self.assertIsNone(dl._match_filter(ok))
-        too_long = {'duration': 20000, 'title': 'c'}
+        too_long = {'duration': 30000, 'title': 'c'}
         self.assertIsNotNone(dl._match_filter(too_long))
 
 if __name__ == '__main__':

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+import sitecustomize


### PR DESCRIPTION
## Summary
- only clear analyzer tables when the analyze step starts
- ensure tests import sitecustomize for stubs
- fix SoundCloud downloader test to match duration limit
- add regression test for analyzer start behaviour

## Testing
- `python -m unittest discover -p '*Test.py'`

------
https://chatgpt.com/codex/tasks/task_e_6875eec284548326ab6949e85062add8