### PR TITLE
Add coverage reporting to GitHub workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,6 +18,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Run unit tests
+    - name: Run tests with coverage
       run: |
-        python -m unittest discover -p "*Test.py" tests
+        coverage run --source=. -m unittest discover -p "*Test.py" tests
+        coverage xml
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-report
+        path: coverage.xml


### PR DESCRIPTION
## Summary
- run unit tests with coverage
- generate an XML coverage report
- upload the report as a workflow artifact

## Testing
- `python -m unittest discover -p "*Test.py" tests`

------
https://chatgpt.com/codex/tasks/task_e_6875fca0ce2c8326890649b4b639766c