### PR TITLE
Add VerifyArtistRule

### DIFF
--- a/downloader/soundcloud.py
+++ b/downloader/soundcloud.py
@@ -104,6 +104,8 @@ class SoundcloudDownloader:
                     wait_time = random.randint(60, 300)
                     logging.warning(f"403 Forbidden for {name}. Pausing {wait_time}s before retry...")
                     time.sleep(wait_time)
+                elif '404' in msg:
+                    logging.info(f"Got 404 for {name} — skip song.")
                 elif 'already in the archive' in msg:
                     logging.info(f"All tracks for {name} already in archive — skipping.")
                     return  # ✅ don't retry

--- a/main.py
+++ b/main.py
@@ -55,6 +55,10 @@ def main():
         help="optional dj",
     )
     parser.add_argument(
+        "--sleeptime",
+        help="time to sleep between repeating steps",
+    )
+    parser.add_argument(
         "--break-on-existing",
         help="optional break on existing for downloaders",
         action="store_true"
@@ -155,8 +159,8 @@ def main():
         if not args.repeat:
             break
 
-        logging.info(f"Waiting for 3600 seconds.")
-        sleep(300)
+        logging.info(f"Waiting for {args.sleeptime or 300} seconds.")
+        sleep(int(args.sleeptime) or 300)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from postprocessing.repair import FileRepair
 from postprocessing.sanitizer import Sanitizer
 from postprocessing.tagger import Tagger
 from postprocessing.analyze import Analyze
+from postprocessing.artistfixer import ArtistFixer
 from processing.converter import Converter
 from processing.epsflattener import EpsFlattener
 from processing.extractor import Extractor
@@ -87,6 +88,7 @@ def main():
     flattener = EpsFlattener()
     repair = FileRepair()
     analyze_step = Analyze()
+    artist_fixer = ArtistFixer()
 
     steps = args.step.split(",") if args.step != "all" else ["all"]
 
@@ -100,7 +102,8 @@ def main():
         "repair",
         "sanitize",
         "tag", "tag-generic", "tag-labels", "tag-soundcloud", "tag-youtube", "tag-telegram",
-        "analyze"
+        "analyze",
+        "artistfixer"
     }
     for step in steps:
         if step not in valid_steps:
@@ -132,6 +135,7 @@ def main():
             args.account or ""
         )),
         Step("Analyze", ["analyze"], analyze_step.run),
+        Step("ArtistFixer", ["artistfixer"], artist_fixer.run),
         Step("Tagger", ["tag", "tag-labels", "tag-soundcloud", "tag-youtube", "tag-generic", "tag-telegram"], run_tagger),
     ]
 

--- a/postprocessing/Song/Helpers/TableHelper.py
+++ b/postprocessing/Song/Helpers/TableHelper.py
@@ -61,6 +61,10 @@ class TableHelper:
             return key.title()
 
     def add(self, key: str) -> bool:
+        # Update cache if enabled
+        if self.cache_enabled:
+            self._values.add(key)
+            self._canonical_map[key.lower()] = key
         query = f"INSERT INTO {self.table_name} ({self.column_name}) VALUES (%s)"
         connection = self.db_connector.connect()
 

--- a/postprocessing/Song/rules/ExternalArtistLookup.py
+++ b/postprocessing/Song/rules/ExternalArtistLookup.py
@@ -8,6 +8,7 @@ class DiscogsLookup:
     API_URL = "https://api.discogs.com/database/search"
 
     def __init__(self, token: Optional[str] = None):
+        self.name = "Discogs"
         self.token = token or os.getenv("DISCOGS_TOKEN")
 
     def is_known_artist(self, name: str) -> bool:
@@ -33,6 +34,8 @@ class DiscogsLookup:
 class MusicBrainzLookup:
     API_URL = "https://musicbrainz.org/ws/2/artist"
 
+    def __init__(self):
+        self.name = "MusicBrainz"
     def is_known_artist(self, name: str) -> bool:
         try:
             response = requests.get(
@@ -56,6 +59,7 @@ class LastfmLookup:
     API_URL = "https://ws.audioscrobbler.com/2.0/"
 
     def __init__(self, api_key: Optional[str] = None):
+        self.name = "Last.fm"
         self.api_key = api_key or os.getenv("LASTFM_API_KEY")
 
     def is_known_artist(self, name: str) -> bool:
@@ -88,6 +92,7 @@ class SpotifyLookup:
     SEARCH_URL = "https://api.spotify.com/v1/search"
 
     def __init__(self, client_id: Optional[str] = None, client_secret: Optional[str] = None):
+        self.name = "Spotify"
         self.client_id = client_id or os.getenv("SPOTIFY_CLIENT_ID")
         self.client_secret = client_secret or os.getenv("SPOTIFY_CLIENT_SECRET")
         self._token: Optional[str] = None
@@ -148,6 +153,7 @@ class ExternalArtistLookup:
         for service in self.services:
             try:
                 if service.is_known_artist(name):
+                    print(f"found at service: {service.name}")
                     return True
             except Exception as e:
                 logging.error("Lookup error with %s: %s", service.__class__.__name__, e)

--- a/postprocessing/Song/rules/ExternalArtistLookup.py
+++ b/postprocessing/Song/rules/ExternalArtistLookup.py
@@ -1,9 +1,154 @@
-class ExternalArtistLookup:
-    """Placeholder for external artist lookups via Discogs, MusicBrainz or Last.fm"""
+import os
+import logging
+import requests
+from typing import Optional
 
-    @staticmethod
-    def is_known_artist(name: str) -> bool:
-        """Stub method to check if an artist exists on external services.
-        Returns False by default and should be implemented elsewhere.
-        """
+
+class DiscogsLookup:
+    API_URL = "https://api.discogs.com/database/search"
+
+    def __init__(self, token: Optional[str] = None):
+        self.token = token or os.getenv("DISCOGS_TOKEN")
+
+    def is_known_artist(self, name: str) -> bool:
+        if not self.token:
+            return False
+        try:
+            response = requests.get(
+                self.API_URL,
+                params={"q": name, "type": "artist", "token": self.token},
+                timeout=5,
+            )
+            if response.status_code != 200:
+                return False
+            data = response.json()
+            for result in data.get("results", []):
+                if result.get("title", "").lower() == name.lower():
+                    return True
+        except Exception as e:
+            logging.error("Discogs lookup failed: %s", e)
+        return False
+
+
+class MusicBrainzLookup:
+    API_URL = "https://musicbrainz.org/ws/2/artist"
+
+    def is_known_artist(self, name: str) -> bool:
+        try:
+            response = requests.get(
+                self.API_URL,
+                params={"query": name, "fmt": "json", "limit": 1},
+                headers={"User-Agent": "MusicImporter/1.0 (codex@example.com)"},
+                timeout=5,
+            )
+            if response.status_code != 200:
+                return False
+            data = response.json()
+            for artist in data.get("artists", []):
+                if artist.get("name", "").lower() == name.lower():
+                    return True
+        except Exception as e:
+            logging.error("MusicBrainz lookup failed: %s", e)
+        return False
+
+
+class LastfmLookup:
+    API_URL = "https://ws.audioscrobbler.com/2.0/"
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("LASTFM_API_KEY")
+
+    def is_known_artist(self, name: str) -> bool:
+        if not self.api_key:
+            return False
+        try:
+            response = requests.get(
+                self.API_URL,
+                params={
+                    "method": "artist.getinfo",
+                    "artist": name,
+                    "api_key": self.api_key,
+                    "format": "json",
+                },
+                timeout=5,
+            )
+            if response.status_code != 200:
+                return False
+            data = response.json()
+            artist = data.get("artist")
+            if artist and artist.get("name", "").lower() == name.lower():
+                return True
+        except Exception as e:
+            logging.error("Last.fm lookup failed: %s", e)
+        return False
+
+
+class SpotifyLookup:
+    TOKEN_URL = "https://accounts.spotify.com/api/token"
+    SEARCH_URL = "https://api.spotify.com/v1/search"
+
+    def __init__(self, client_id: Optional[str] = None, client_secret: Optional[str] = None):
+        self.client_id = client_id or os.getenv("SPOTIFY_CLIENT_ID")
+        self.client_secret = client_secret or os.getenv("SPOTIFY_CLIENT_SECRET")
+        self._token: Optional[str] = None
+
+    def _get_token(self) -> Optional[str]:
+        if self._token:
+            return self._token
+        if not self.client_id or not self.client_secret:
+            return None
+        try:
+            resp = requests.post(
+                self.TOKEN_URL,
+                data={"grant_type": "client_credentials"},
+                auth=(self.client_id, self.client_secret),
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                self._token = resp.json().get("access_token")
+        except Exception as e:
+            logging.error("Spotify token retrieval failed: %s", e)
+        return self._token
+
+    def is_known_artist(self, name: str) -> bool:
+        token = self._get_token()
+        if not token:
+            return False
+        try:
+            response = requests.get(
+                self.SEARCH_URL,
+                params={"q": name, "type": "artist", "limit": 1},
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=5,
+            )
+            if response.status_code != 200:
+                return False
+            data = response.json()
+            artists = data.get("artists", {}).get("items", [])
+            for artist in artists:
+                if artist.get("name", "").lower() == name.lower():
+                    return True
+        except Exception as e:
+            logging.error("Spotify lookup failed: %s", e)
+        return False
+
+
+class ExternalArtistLookup:
+    """Check if an artist exists on various external music services."""
+
+    def __init__(self):
+        self.services = [
+            DiscogsLookup(),
+            MusicBrainzLookup(),
+            LastfmLookup(),
+            SpotifyLookup(),
+        ]
+
+    def is_known_artist(self, name: str) -> bool:
+        for service in self.services:
+            try:
+                if service.is_known_artist(name):
+                    return True
+            except Exception as e:
+                logging.error("Lookup error with %s: %s", service.__class__.__name__, e)
         return False

--- a/postprocessing/Song/rules/ExternalArtistLookup.py
+++ b/postprocessing/Song/rules/ExternalArtistLookup.py
@@ -1,0 +1,9 @@
+class ExternalArtistLookup:
+    """Placeholder for external artist lookups via Discogs, MusicBrainz or Last.fm"""
+
+    @staticmethod
+    def is_known_artist(name: str) -> bool:
+        """Stub method to check if an artist exists on external services.
+        Returns False by default and should be implemented elsewhere.
+        """
+        return False

--- a/postprocessing/Song/rules/InferArtistFromTitleRule.py
+++ b/postprocessing/Song/rules/InferArtistFromTitleRule.py
@@ -77,9 +77,8 @@ class InferArtistFromTitleRule(TagRule):
         ]
 
     def apply(self, song):
-        title = song.tag_collection.get_item_as_string(TITLE)
-        if not song.tag_collection.has_item(ORIGINAL_TITLE) and any(c in title for c in ['-', '@', ':']):
-            song.tag_collection.set_item(ORIGINAL_TITLE, title)
+        if not song.tag_collection.has_item(ORIGINAL_TITLE):
+            song.tag_collection.set_item(ORIGINAL_TITLE, song.tag_collection.get_item_as_string(TITLE))
 
         for rule in self.rules:
             if rule.apply(song):
@@ -159,8 +158,6 @@ class InferArtistFromTitleSingleDashRule(TagRule):
     def apply(self, song):
         title = song.tag_collection.get_item_as_string(ORIGINAL_TITLE)
         title = title.replace('|','-')
-        if title != 'All I Wanna Do':
-            title = title.replace(' I ',' - ')
         if not title or title.count(" - ") != 1:
             return False
         left, right = [s.strip() for s in title.split(" - ", 1)]
@@ -202,8 +199,7 @@ class InferArtistFromTitleMultiDashRule(TagRule):
         title = song.tag_collection.get_item_as_string(ORIGINAL_TITLE)
         title = title.replace('|','-')
         title = title.replace('｜','-')
-        if title != 'All I Wanna Do':
-            title = title.replace(' I ',' - ')
+        title = title.replace(' I ',' - ')
         title = title.replace(' warmup mix ',' warmup mix - ')
         title = title.replace(' warm-up mix ',' warm-up mix - ')
         if not title or " - " not in title:

--- a/postprocessing/Song/rules/InferArtistFromTitleRuleTest.py
+++ b/postprocessing/Song/rules/InferArtistFromTitleRuleTest.py
@@ -198,7 +198,7 @@ class InferArtistFromTitleRuleTest(unittest.TestCase):
     def test_no_dash_in_title(self):
         self._apply_rule("Just One Part Title")
         self.song.tag_collection.set_artist.assert_not_called()
-        self.song.tag_collection.set_item.assert_not_called()
+        self.song.tag_collection.set_item.assert_any_call(ORIGINAL_TITLE, "Just One Part Title")
 
     def test_original_is_set(self):
         self._apply_rule("Headhunterz - From Within")

--- a/postprocessing/Song/rules/TagResult.py
+++ b/postprocessing/Song/rules/TagResult.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+
+class TagResultType(Enum):
+    VALID = auto()
+    UPDATED = auto()
+    IGNORED = auto()
+    UNKNOWN = auto()
+
+@dataclass
+class TagResult:
+    value: str | None
+    result_type: TagResultType

--- a/postprocessing/Song/rules/VerifyArtistRule.py
+++ b/postprocessing/Song/rules/VerifyArtistRule.py
@@ -28,8 +28,9 @@ class VerifyArtistRule(TagRule):
     NUMERIC_PREFIX = re.compile(r"^#?\d{1,3}[.)\s-]+")
     INVALID_START = re.compile(r"^[#\-\(\*'\"\[]+")
 
-    def __init__(self, artist_db: Optional[TableHelper] = None):
+    def __init__(self, artist_db: Optional[TableHelper] = None, lookup: Optional[ExternalArtistLookup] = None):
         self.artist_db = artist_db or TableHelper("artists", "name")
+        self.lookup = lookup or ExternalArtistLookup()
         self.seen_counts: defaultdict[str, int] = defaultdict(int)
 
     def _heuristic_check(self, name: str) -> tuple[str, bool, bool]:
@@ -106,7 +107,7 @@ class VerifyArtistRule(TagRule):
             return TagResult(artist, TagResultType.VALID)
 
         # Step 2: external lookup
-        if ExternalArtistLookup.is_known_artist(artist):
+        if self.lookup.is_known_artist(artist):
             insert = getattr(self.artist_db, "insert_if_not_exists", None)
             if callable(insert):
                 insert(artist)

--- a/postprocessing/Song/rules/VerifyArtistRule.py
+++ b/postprocessing/Song/rules/VerifyArtistRule.py
@@ -1,0 +1,131 @@
+import logging
+import re
+from collections import defaultdict
+from typing import Optional
+
+from postprocessing.Song.Helpers.TableHelper import TableHelper
+from postprocessing.Song.rules.TagRule import TagRule
+from postprocessing.Song.rules.TagResult import TagResult, TagResultType
+from postprocessing.Song.rules.ExternalArtistLookup import ExternalArtistLookup
+from postprocessing.constants import ARTIST
+
+logger = logging.getLogger(__name__)
+
+
+class VerifyArtistRule(TagRule):
+    """Validate and normalize the ARTIST tag of a song."""
+
+    PLACEHOLDERS = [
+        "unknown artist",
+        "various artists",
+        "on toxic sickness radio",
+        "live at",
+        "year anniversary",
+        "hardcore special",
+    ]
+
+    NUMERIC_ONLY = re.compile(r"^#?\d+[.)]?$")
+    NUMERIC_PREFIX = re.compile(r"^#?\d{1,3}[.)\s-]+")
+    INVALID_START = re.compile(r"^[#\-\(\*'\"\[]+")
+
+    def __init__(self, artist_db: Optional[TableHelper] = None):
+        self.artist_db = artist_db or TableHelper("artists", "name")
+        self.seen_counts: defaultdict[str, int] = defaultdict(int)
+
+    def _heuristic_check(self, name: str) -> tuple[str, bool, bool]:
+        """Return (clean_name, changed, invalid)"""
+        original = name
+        name = name.strip()
+
+        # numeric only
+        if self.NUMERIC_ONLY.fullmatch(name):
+            return name, False, True
+
+        # numeric prefix
+        prefix = self.NUMERIC_PREFIX.match(name)
+        if prefix:
+            name = name[prefix.end():].strip()
+            if not name:
+                return original, False, True
+            return name, True, False
+
+        # start with strange chars
+        cleaned = self.INVALID_START.sub("", name).strip()
+        if cleaned != name:
+            name = cleaned
+            if not name:
+                return original, False, True
+            changed = True
+        else:
+            changed = False
+
+        # unbalanced brackets/quotes
+        if name.count("(") != name.count(")"):
+            name = name.replace("(", "").replace(")", "")
+            changed = True
+        if name.count("[") != name.count("]"):
+            name = name.replace("[", "").replace("]", "")
+            changed = True
+        if name.count('"') % 2 == 1:
+            name = name.replace('"', "")
+            changed = True
+        if name.count("'") % 2 == 1:
+            name = name.replace("'", "")
+            changed = True
+
+        # length/composition checks
+        if len(name) <= 2 and not re.search(r"[A-Za-z]", name):
+            return original, False, True
+        if not re.search(r"[A-Za-z]", name):
+            return original, False, True
+
+        # placeholders
+        lower = name.lower()
+        for frag in self.PLACEHOLDERS:
+            if frag in lower:
+                return original, False, True
+
+        return name, changed, False
+
+    def apply(self, song) -> TagResult:
+        artist = song.artist()
+        if not artist:
+            return TagResult(None, TagResultType.UNKNOWN)
+
+        tag_item = song.tag_collection.get_item(ARTIST)
+        self.seen_counts[artist.lower()] += 1
+
+        # Step 1: check database
+        if self.artist_db.exists(artist):
+            canonical = self.artist_db.get(artist)
+            if canonical != artist:
+                tag_item.remove(artist)
+                tag_item.add(canonical)
+                logger.info("Updated artist casing '%s' -> '%s'", artist, canonical)
+                return TagResult(canonical, TagResultType.UPDATED)
+            return TagResult(artist, TagResultType.VALID)
+
+        # Step 2: external lookup
+        if ExternalArtistLookup.is_known_artist(artist):
+            insert = getattr(self.artist_db, "insert_if_not_exists", None)
+            if callable(insert):
+                insert(artist)
+            else:
+                if not self.artist_db.exists(artist):
+                    self.artist_db.add(artist)
+            logger.info("Added artist '%s' from external lookup", artist)
+            return TagResult(artist, TagResultType.VALID)
+
+        # Step 3: heuristics
+        cleaned, changed, invalid = self._heuristic_check(artist)
+        if invalid:
+            tag_item.remove(artist)
+            logger.info("Ignored invalid artist '%s'", artist)
+            return TagResult(artist, TagResultType.IGNORED)
+        if changed and cleaned != artist:
+            tag_item.remove(artist)
+            tag_item.add(cleaned)
+            logger.info("Cleaned artist '%s' -> '%s'", artist, cleaned)
+            return TagResult(cleaned, TagResultType.UPDATED)
+
+        return TagResult(artist, TagResultType.UNKNOWN)

--- a/postprocessing/Song/rules/VerifyArtistRule.py
+++ b/postprocessing/Song/rules/VerifyArtistRule.py
@@ -70,9 +70,6 @@ class VerifyArtistRule(TagRule):
         if name.count('"') % 2 == 1:
             name = name.replace('"', "")
             changed = True
-        if name.count("'") % 2 == 1:
-            name = name.replace("'", "")
-            changed = True
 
         # length/composition checks
         if len(name) <= 2 and not re.search(r"[A-Za-z]", name):
@@ -89,44 +86,45 @@ class VerifyArtistRule(TagRule):
         return name, changed, False
 
     def apply(self, song) -> TagResult:
-        artist = song.artist()
-        if not artist:
-            return TagResult(None, TagResultType.UNKNOWN)
+        artists = song.artists()
+        for artist in artists:
+            if not artist:
+                return TagResult(None, TagResultType.UNKNOWN)
 
-        tag_item = song.tag_collection.get_item(ARTIST)
-        self.seen_counts[artist.lower()] += 1
+            tag_item = song.tag_collection.get_item(ARTIST)
+            self.seen_counts[artist.lower()] += 1
 
-        # Step 1: check database
-        if self.artist_db.exists(artist):
-            canonical = self.artist_db.get(artist)
-            if canonical != artist:
-                tag_item.remove(artist)
-                tag_item.add(canonical)
-                logger.info("Updated artist casing '%s' -> '%s'", artist, canonical)
-                return TagResult(canonical, TagResultType.UPDATED)
-            return TagResult(artist, TagResultType.VALID)
+            # Step 1: check database
+            if self.artist_db.exists(artist):
+                canonical = self.artist_db.get(artist)
+                if canonical != artist:
+                    tag_item.remove(artist)
+                    tag_item.add(canonical)
+                    logger.info("Updated artist casing '%s' -> '%s'", artist, canonical)
+                    return TagResult(canonical, TagResultType.UPDATED)
+                return TagResult(artist, TagResultType.VALID)
 
-        # Step 2: external lookup
-        if self.lookup.is_known_artist(artist):
-            insert = getattr(self.artist_db, "insert_if_not_exists", None)
-            if callable(insert):
-                insert(artist)
-            else:
-                if not self.artist_db.exists(artist):
-                    self.artist_db.add(artist)
-            logger.info("Added artist '%s' from external lookup", artist)
-            return TagResult(artist, TagResultType.VALID)
+            # Step 2: external lookup
+            if self.lookup.is_known_artist(artist):
+                insert = getattr(self.artist_db, "insert_if_not_exists", None)
+                if callable(insert):
+                    insert(artist)
+                else:
+                    if not self.artist_db.exists(artist):
+                        self.artist_db.add(artist)
+                logger.info("Added artist '%s' from external lookup", artist)
+                return TagResult(artist, TagResultType.VALID)
+            #
+            # Step 3: heuristics
+            cleaned, changed, invalid = self._heuristic_check(artist)
+            if invalid:
+                # tag_item.remove(artist)
+                logger.info("Ignored invalid artist '%s'", artist)
+                return TagResult(artist, TagResultType.IGNORED)
+            if changed and cleaned != artist:
+                # tag_item.remove(artist)
+                # tag_item.add(cleaned)
+                logger.info("Cleaned artist '%s' -> '%s'", artist, cleaned)
+                return TagResult(cleaned, TagResultType.UPDATED)
 
-        # Step 3: heuristics
-        cleaned, changed, invalid = self._heuristic_check(artist)
-        if invalid:
-            tag_item.remove(artist)
-            logger.info("Ignored invalid artist '%s'", artist)
-            return TagResult(artist, TagResultType.IGNORED)
-        if changed and cleaned != artist:
-            tag_item.remove(artist)
-            tag_item.add(cleaned)
-            logger.info("Cleaned artist '%s' -> '%s'", artist, cleaned)
-            return TagResult(cleaned, TagResultType.UPDATED)
-
-        return TagResult(artist, TagResultType.UNKNOWN)
+            return TagResult(artist, TagResultType.UNKNOWN)

--- a/postprocessing/Song/rules/VerifyArtistRuleTest.py
+++ b/postprocessing/Song/rules/VerifyArtistRuleTest.py
@@ -1,5 +1,10 @@
+import sys
+import types
 import unittest
 from unittest.mock import MagicMock, patch
+
+# stub requests so ExternalArtistLookup can be imported without dependency
+sys.modules.setdefault('requests', types.ModuleType('requests'))
 
 from postprocessing.Song.rules.VerifyArtistRule import VerifyArtistRule
 from postprocessing.Song.rules.TagResult import TagResultType
@@ -12,6 +17,14 @@ class VerifyArtistRuleTest(unittest.TestCase):
         self.song.artist.return_value = "Unknown"
         self.song.tag_collection.get_item.return_value = self.tag
         self.artist_db = MagicMock()
+
+        # default: external lookup returns False
+        patcher = patch(
+            "postprocessing.Song.rules.ExternalArtistLookup.ExternalArtistLookup.is_known_artist",
+            return_value=False,
+        )
+        self.addCleanup(patcher.stop)
+        self.mock_lookup_default = patcher.start()
 
     def test_existing_artist_updates_casing(self):
         self.song.artist.return_value = "angerfist"

--- a/postprocessing/Song/rules/VerifyArtistRuleTest.py
+++ b/postprocessing/Song/rules/VerifyArtistRuleTest.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from postprocessing.Song.rules.VerifyArtistRule import VerifyArtistRule
+from postprocessing.Song.rules.TagResult import TagResultType
+
+
+class VerifyArtistRuleTest(unittest.TestCase):
+    def setUp(self):
+        self.tag = MagicMock()
+        self.song = MagicMock()
+        self.song.artist.return_value = "Unknown"
+        self.song.tag_collection.get_item.return_value = self.tag
+        self.artist_db = MagicMock()
+
+    def test_existing_artist_updates_casing(self):
+        self.song.artist.return_value = "angerfist"
+        self.artist_db.exists.return_value = True
+        self.artist_db.get.return_value = "Angerfist"
+        rule = VerifyArtistRule(self.artist_db)
+
+        result = rule.apply(self.song)
+
+        self.tag.remove.assert_called_once_with("angerfist")
+        self.tag.add.assert_called_once_with("Angerfist")
+        self.assertEqual(result.result_type, TagResultType.UPDATED)
+        self.assertEqual(result.value, "Angerfist")
+
+    @patch("postprocessing.Song.rules.ExternalArtistLookup.ExternalArtistLookup.is_known_artist", return_value=True)
+    def test_external_lookup_adds_artist(self, mock_lookup):
+        self.song.artist.return_value = "New Artist"
+        self.artist_db.exists.return_value = False
+        # simulate insert_if_not_exists callable
+        self.artist_db.insert_if_not_exists = MagicMock()
+        rule = VerifyArtistRule(self.artist_db)
+
+        result = rule.apply(self.song)
+
+        self.artist_db.insert_if_not_exists.assert_called_once_with("New Artist")
+        self.assertEqual(result.result_type, TagResultType.VALID)
+
+    def test_numeric_only_artist_is_ignored(self):
+        self.song.artist.return_value = "001"
+        self.artist_db.exists.return_value = False
+        rule = VerifyArtistRule(self.artist_db)
+
+        result = rule.apply(self.song)
+
+        self.tag.remove.assert_called_once_with("001")
+        self.assertEqual(result.result_type, TagResultType.IGNORED)
+
+    def test_numeric_prefix_is_stripped(self):
+        self.song.artist.return_value = "005. Radical Redemption"
+        self.artist_db.exists.return_value = False
+        rule = VerifyArtistRule(self.artist_db)
+
+        result = rule.apply(self.song)
+
+        self.tag.remove.assert_called_once_with("005. Radical Redemption")
+        self.tag.add.assert_called_once_with("Radical Redemption")
+        self.assertEqual(result.result_type, TagResultType.UPDATED)
+
+    def test_placeholder_artist_is_ignored(self):
+        self.song.artist.return_value = "Unknown Artist"
+        self.artist_db.exists.return_value = False
+        rule = VerifyArtistRule(self.artist_db)
+
+        result = rule.apply(self.song)
+
+        self.tag.remove.assert_called_once_with("Unknown Artist")
+        self.assertEqual(result.result_type, TagResultType.IGNORED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/postprocessing/artistfixer.py
+++ b/postprocessing/artistfixer.py
@@ -1,0 +1,66 @@
+import logging
+from pathlib import Path
+
+from mutagen import MutagenError
+
+from data.settings import Settings
+from postprocessing.Song.BaseSong import BaseSong, ExtensionNotSupportedException
+from postprocessing.Song.Helpers.Cache import databaseHelpers
+from postprocessing.Song.rules.VerifyArtistRule import VerifyArtistRule
+from postprocessing.Song.rules.TagResult import TagResultType
+
+
+class ArtistFixer:
+    """Iterate over all songs and fix the ARTIST tag using VerifyArtistRule."""
+
+    def __init__(self):
+        self.settings = Settings()
+        self.artist_db = databaseHelpers["artists"]
+        self.rule = VerifyArtistRule(self.artist_db)
+        self.extensions = {
+            "mp3": True,
+            "flac": True,
+            "wav": False,
+            "m4a": True,
+            "aac": False,
+        }
+
+    def run(self):
+        logging.info("Starting Artist Fixer Step")
+        root = Path(self.settings.music_folder_path)
+        if root.exists():
+            self._parse_folder(root)
+
+    def _parse_folder(self, folder: Path):
+        if "@eaDir" in str(folder):
+            return
+        try:
+            files: list[Path] = []
+            for ext, enabled in self.extensions.items():
+                if enabled:
+                    files.extend(folder.glob(f"*.{ext}"))
+            for file in files:
+                self._fix_file(file)
+            for sub in [f for f in folder.iterdir() if f.is_dir() and not f.name.startswith("_")]:
+                self._parse_folder(sub)
+        except Exception as e:
+            logging.error(f"Error processing folder {folder}: {e}", exc_info=True)
+
+    def _fix_file(self, path: Path):
+        try:
+            song = BaseSong(str(path))
+            original = song.artist()
+            was_known = self.artist_db.exists(original) if original else True
+            result = self.rule.apply(song)
+            song.save_file()
+
+            if result.result_type == TagResultType.VALID and not was_known:
+                print(f"✅ added '{original}' to artists table")
+            elif result.result_type == TagResultType.UPDATED:
+                print(f"✏️ updated '{original}' -> '{result.value}'")
+            elif result.result_type == TagResultType.IGNORED:
+                print(f"🗑️ removed invalid artist '{original}'")
+        except (PermissionError, MutagenError, FileNotFoundError, ExtensionNotSupportedException) as e:
+            logging.warning(f"{type(e).__name__}: {e} -> {path}")
+        except Exception as e:
+            logging.error(f"Artist fix failed: {e} -> {path}", exc_info=True)

--- a/postprocessing/artistfixer.py
+++ b/postprocessing/artistfixer.py
@@ -54,12 +54,12 @@ class ArtistFixer:
             result = self.rule.apply(song)
             song.save_file()
 
-            if result.result_type == TagResultType.VALID and not was_known:
-                print(f"✅ added '{original}' to artists table")
-            elif result.result_type == TagResultType.UPDATED:
-                print(f"✏️ updated '{original}' -> '{result.value}'")
-            elif result.result_type == TagResultType.IGNORED:
-                print(f"🗑️ removed invalid artist '{original}'")
+            # if result.result_type == TagResultType.VALID and not was_known:
+            #     print(f"✅ added '{original}' to artists table")
+            # elif result.result_type == TagResultType.UPDATED:
+            #     print(f"✏️ updated '{original}' -> '{result.value}'")
+            # elif result.result_type == TagResultType.IGNORED:
+            #     print(f"🗑️ removed invalid artist '{original}'")
         except (PermissionError, MutagenError, FileNotFoundError, ExtensionNotSupportedException) as e:
             logging.warning(f"{type(e).__name__}: {e} -> {path}")
         except Exception as e:

--- a/tests/ArtistFixerTest.py
+++ b/tests/ArtistFixerTest.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import types
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# provide minimal env vars for Settings
+os.environ.setdefault('import_folder_path', '/tmp')
+os.environ.setdefault('eps_folder_path', '/tmp')
+os.environ.setdefault('delimiter', '/')
+# will set music_folder_path in setUp
+
+# stub dotenv
+sys.modules['dotenv'] = types.ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda *a, **k: None
+
+# stub requests used by ExternalArtistLookup
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+
+# ensure mutagen module provides MutagenError for artistfixer import
+mutagen_mod = sys.modules.setdefault('mutagen', types.ModuleType('mutagen'))
+setattr(mutagen_mod, 'MutagenError', Exception)
+
+# prepare stub Cache module before importing ArtistFixer
+cache_mod = types.ModuleType('postprocessing.Song.Helpers.Cache')
+cache_mod.databaseHelpers = {"artists": MagicMock()}
+sys.modules['postprocessing.Song.Helpers.Cache'] = cache_mod
+
+from postprocessing.Song.rules.TagResult import TagResult, TagResultType
+import importlib
+import postprocessing.artistfixer as artistfixer
+
+class ArtistFixerTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        os.environ['music_folder_path'] = self.tempdir.name
+
+        # create some dummy files
+        Path(self.tempdir.name, 'one.mp3').touch()
+        Path(self.tempdir.name, 'two.flac').touch()
+        sub = Path(self.tempdir.name, 'sub'); sub.mkdir()
+        Path(sub, 'three.m4a').touch()
+        Path(sub, 'skip.txt').touch()
+
+        self.created_paths = []
+        def fake_base_song(path):
+            self.created_paths.append(Path(path))
+            song = MagicMock()
+            song.artist.return_value = 'New Artist'
+            song.tag_collection.get_item.return_value = MagicMock()
+            song.save_file.return_value = None
+            return song
+
+        self.rule_instance = MagicMock()
+        self.rule_instance.apply.return_value = TagResult('New Artist', TagResultType.VALID)
+
+        importlib.reload(artistfixer)
+        self.artist_db = artistfixer.databaseHelpers['artists']
+        self.artist_db.exists.return_value = False
+
+        self.patcher_settings = patch.object(
+            artistfixer,
+            'Settings',
+            return_value=types.SimpleNamespace(music_folder_path=self.tempdir.name)
+        )
+        self.patcher_bs = patch.object(artistfixer, 'BaseSong', side_effect=fake_base_song)
+        self.patcher_rule = patch.object(artistfixer, 'VerifyArtistRule', return_value=self.rule_instance)
+        for p in (self.patcher_settings, self.patcher_bs, self.patcher_rule):
+            p.start()
+            self.addCleanup(p.stop)
+        self.addCleanup(self.tempdir.cleanup)
+
+        self.fix = artistfixer.ArtistFixer()
+
+    def test_run_processes_supported_files(self):
+        with patch('builtins.print') as mock_print:
+            self.fix.run()
+
+        # three supported files should be processed
+        self.assertEqual(len(self.created_paths), 3)
+        self.assertEqual(self.rule_instance.apply.call_count, 3)
+        # prints should indicate artists were added
+        self.assertTrue(all('artists table' in call.args[0] for call in mock_print.call_args_list))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a small result helper with `TagResult` and `TagResultType`
- implement `ExternalArtistLookup` placeholder
- add new `VerifyArtistRule` with heuristic cleanup and database lookups
- test `VerifyArtistRule`

## Testing
- `python -m unittest discover -p "*Test.py"`

------
https://chatgpt.com/codex/tasks/task_e_687730fffbe483268104cb1126bf46e4