### PR TITLE
Add Unicode cleanup rule for tags

### DIFF
--- a/postprocessing/Song/GenericSong.py
+++ b/postprocessing/Song/GenericSong.py
@@ -9,6 +9,7 @@ from postprocessing.Song.rules.CleanTagsRule import CleanTagsRule
 from postprocessing.Song.rules.InferGenreFromArtistRule import InferGenreFromArtistRule
 from postprocessing.Song.rules.InferGenreFromSubgenreRule import InferGenreFromSubgenreRule
 from postprocessing.Song.rules.InferRemixerFromTitleRule import InferRemixerFromTitleRule
+from postprocessing.Song.rules.ReplaceInvalidUnicodeRule import ReplaceInvalidUnicodeRule
 from postprocessing.constants import ALBUM_ARTIST, PUBLISHER, CATALOG_NUMBER, GENRE, ARTIST, COPYRIGHT, FormatEnum
 
 s = Settings()
@@ -60,6 +61,8 @@ class GenericSong(BaseSong):
             artist_db=databaseHelpers["artists"],
             ignored_db=databaseHelpers["ignored_artists"]
         ))  # Normalize/correct/remove tags based on artist DB state
+
+        self.rules.append(ReplaceInvalidUnicodeRule())
 
         super().parse()
 

--- a/postprocessing/Song/LabelSong.py
+++ b/postprocessing/Song/LabelSong.py
@@ -9,6 +9,7 @@ from postprocessing.Song.rules.CleanTagsRule import CleanTagsRule
 from postprocessing.Song.rules.InferGenreFromArtistRule import InferGenreFromArtistRule
 from postprocessing.Song.rules.InferGenreFromSubgenreRule import InferGenreFromSubgenreRule
 from postprocessing.Song.rules.InferRemixerFromTitleRule import InferRemixerFromTitleRule
+from postprocessing.Song.rules.ReplaceInvalidUnicodeRule import ReplaceInvalidUnicodeRule
 from postprocessing.constants import (
     PUBLISHER, CATALOG_NUMBER, COPYRIGHT,
 )
@@ -69,6 +70,8 @@ class LabelSong(BaseSong):
             artist_db=databaseHelpers["artists"],
             ignored_db=databaseHelpers["ignored_artists"]
         ))  # Normalize/correct/remove tags based on artist DB state
+
+        self.rules.append(ReplaceInvalidUnicodeRule())
 
         super().parse()
 

--- a/postprocessing/Song/SoundcloudSong.py
+++ b/postprocessing/Song/SoundcloudSong.py
@@ -16,6 +16,7 @@ from postprocessing.Song.rules.InferGenreFromSubgenreRule import InferGenreFromS
 from postprocessing.Song.rules.InferGenreFromTitleRule import InferGenreFromTitleRule
 from postprocessing.Song.rules.InferRemixerFromTitleRule import InferRemixerFromTitleRule
 from postprocessing.Song.rules.MergeDrumAndBassGenresRule import MergeDrumAndBassGenresRule
+from postprocessing.Song.rules.ReplaceInvalidUnicodeRule import ReplaceInvalidUnicodeRule
 from postprocessing.constants import ALBUM_ARTIST, PUBLISHER, CATALOG_NUMBER, GENRE, ARTIST, COPYRIGHT, FormatEnum, \
     TITLE
 
@@ -80,6 +81,8 @@ class SoundcloudSong(BaseSong):
             artist_db=databaseHelpers["artists"],
             ignored_db=databaseHelpers["ignored_artists"]
         ))  # Normalize/correct/remove tags based on artist DB state
+
+        self.rules.append(ReplaceInvalidUnicodeRule())
 
         super().parse()
 

--- a/postprocessing/Song/YoutubeSong.py
+++ b/postprocessing/Song/YoutubeSong.py
@@ -7,6 +7,7 @@ from postprocessing.Song.rules.InferGenreFromAlbumArtistRule import InferGenreFr
 from postprocessing.Song.rules.InferGenreFromArtistRule import InferGenreFromArtistRule
 from postprocessing.Song.rules.InferGenreFromSubgenreRule import InferGenreFromSubgenreRule
 from postprocessing.Song.rules.InferRemixerFromTitleRule import InferRemixerFromTitleRule
+from postprocessing.Song.rules.ReplaceInvalidUnicodeRule import ReplaceInvalidUnicodeRule
 from postprocessing.constants import ALBUM_ARTIST, PUBLISHER, CATALOG_NUMBER, GENRE, ARTIST, COPYRIGHT, FormatEnum, \
     TITLE
 
@@ -39,6 +40,7 @@ class YoutubeSong(BaseSong):
         self.rules.append(InferGenreFromSubgenreRule())
         self.rules.append(CleanTagsRule())
         self.rules.append(CleanAndFilterGenreRule())
+        self.rules.append(ReplaceInvalidUnicodeRule())
         super().parse()
 
     def calculate_copyright(self):

--- a/postprocessing/Song/rules/ReplaceInvalidUnicodeRule.py
+++ b/postprocessing/Song/rules/ReplaceInvalidUnicodeRule.py
@@ -1,0 +1,22 @@
+from postprocessing.Song.rules.TagRule import TagRule
+from postprocessing.constants import ARTIST, ALBUM_ARTIST, GENRE
+
+
+class ReplaceInvalidUnicodeRule(TagRule):
+    """Replace undesirable zero-width characters with semicolons."""
+
+    def __init__(self, invalid_chars=None):
+        self.invalid_chars = invalid_chars or ['\ufeff']
+
+    def apply(self, song):
+        for field in [ARTIST, ALBUM_ARTIST, GENRE]:
+            if song.tag_collection.has_item(field):
+                tag = song.tag_collection.get_item(field)
+                value = tag.to_string()
+                new_value = value
+                for char in self.invalid_chars:
+                    if char in new_value:
+                        new_value = new_value.replace(char, ';')
+                if new_value != value:
+                    tag.set(new_value)
+                    tag.deduplicate()

--- a/postprocessing/Song/rules/ReplaceInvalidUnicodeRuleTest.py
+++ b/postprocessing/Song/rules/ReplaceInvalidUnicodeRuleTest.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import MagicMock
+
+from postprocessing.Song.rules.ReplaceInvalidUnicodeRule import ReplaceInvalidUnicodeRule
+from postprocessing.Song.Tag import Tag
+from postprocessing.constants import ARTIST, ALBUM_ARTIST, GENRE
+
+
+class ReplaceInvalidUnicodeRuleTest(unittest.TestCase):
+    def test_replaces_invalid_unicode_chars(self):
+        rule = ReplaceInvalidUnicodeRule()
+        artist = Tag(ARTIST, f"Soulblast\ufeffChaotic Brotherz\ufeffMaus999")
+        album_artist = Tag(ALBUM_ARTIST, f"Label\ufeffLabel2")
+        genre = Tag(GENRE, f"Hardcore\ufeffUptempo")
+
+        tag_collection = MagicMock()
+        tag_collection.has_item.side_effect = lambda k: True
+        tag_collection.get_item.side_effect = lambda k: {
+            ARTIST: artist,
+            ALBUM_ARTIST: album_artist,
+            GENRE: genre,
+        }[k]
+
+        song = MagicMock()
+        song.tag_collection = tag_collection
+
+        rule.apply(song)
+
+        self.assertEqual(artist.value, ["Soulblast", "Chaotic Brotherz", "Maus999"])
+        self.assertEqual(album_artist.value, ["Label", "Label2"])
+        self.assertEqual(genre.value, ["Hardcore", "Uptempo"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `ReplaceInvalidUnicodeRule` to replace zero-width spaces with semicolons
- append the new rule to all song classes
- test replacement behaviour

## Testing
- `pytest -q $(git ls-files '*Test.py') postprocessing/Song/rules/ReplaceInvalidUnicodeRuleTest.py`

------
https://chatgpt.com/codex/tasks/task_e_68865f7457e483269c6fc41a7b57f865